### PR TITLE
Allowing usage of `https://github.<company>.com/api/v3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The GitHub auth provider supports two additional parameters to restrict authenti
 
 If you are using github enterprise, make sure you set the following to the appropriate url:
 
-    -github-base-url="https://<github domain>/api/v3/"
+    -github-api-url="https://<github domain>/api/v3/"
     -login-url="<enterprise github url>/login/oauth/authorize"
     -redeem-url="<enterprise github url>/login/oauth/access_token"
     -validate-url="<enterprise github api url>/user/emails"

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ The GitHub auth provider supports two additional parameters to restrict authenti
 
 If you are using github enterprise, make sure you set the following to the appropriate url:
 
+    -github-base-url="https://<github domain>/api/v3/"
     -login-url="<enterprise github url>/login/oauth/authorize"
     -redeem-url="<enterprise github url>/login/oauth/access_token"
     -validate-url="<enterprise github api url>/user/emails"
-
 
 ### LinkedIn Auth Provider
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
-	flagSet.String("github-base-url", "", "github base url to configure github enterprise endpoint")
+	flagSet.String("github-api-url", "", "github api url to configure github enterprise endpoint")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
+	flagSet.String("github-base-url", "", "github base url to configure github enterprise endpoint")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")

--- a/options.go
+++ b/options.go
@@ -28,6 +28,7 @@ type Options struct {
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
+	GitHubBaseUrl            string	  `flag:"github-base-url" cfg:"github_base_url"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
@@ -210,6 +211,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	switch p := o.provider.(type) {
 	case *providers.GitHubProvider:
 		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
+		p.SetBaseUrl(o.GitHubBaseUrl)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/options.go
+++ b/options.go
@@ -28,7 +28,7 @@ type Options struct {
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
-	GitHubBaseUrl            string	  `flag:"github-base-url" cfg:"github_base_url"`
+	GitHubApiUrl             string	  `flag:"github-api-url" cfg:"github_api_url"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json"`
@@ -211,7 +211,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	switch p := o.provider.(type) {
 	case *providers.GitHubProvider:
 		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
-		p.SetBaseUrl(o.GitHubBaseUrl)
+		p.SetApiUrl(o.GitHubApiUrl)
 	case *providers.GoogleProvider:
 		if o.GoogleServiceAccountJSON != "" {
 			file, err := os.Open(o.GoogleServiceAccountJSON)

--- a/providers/github.go
+++ b/providers/github.go
@@ -12,9 +12,9 @@ import (
 
 type GitHubProvider struct {
 	*ProviderData
-	Org     string
-	Team    string
-	BaseUrl string
+	Org    string
+	Team   string
+	ApiUrl string
 }
 
 func NewGitHubProvider(p *ProviderData) *GitHubProvider {
@@ -53,13 +53,13 @@ func (p *GitHubProvider) SetOrgTeam(org, team string) {
 	}
 }
 
-func (p *GitHubProvider) SetBaseUrl(uri string) {
+func (p *GitHubProvider) SetApiUrl(uri string) {
 	// Expecting BaseUrl to be https://github.<domain>/api/v3/
-	p.BaseUrl = uri
-	if len(p.BaseUrl) <= 0 {
-		p.BaseUrl = fmt.Sprintf("%s://%s/", p.ValidateURL.Scheme, p.ValidateURL.Host)
-	} else if !strings.HasSuffix(p.BaseUrl, "/") {
-		p.BaseUrl = fmt.Sprintf("%s/", p.BaseUrl)
+	p.ApiUrl = uri
+	if len(p.ApiUrl) <= 0 {
+		p.ApiUrl = fmt.Sprintf("%s://%s/", p.ValidateURL.Scheme, p.ValidateURL.Host)
+	} else if !strings.HasSuffix(p.ApiUrl, "/") {
+		p.ApiUrl = fmt.Sprintf("%s/", p.ApiUrl)
 	}
 }
 
@@ -224,5 +224,5 @@ func (p *GitHubProvider) GetEmailAddress(s *SessionState) (string, error) {
 }
 
 func (p *GitHubProvider) getEndpoint(path string, params url.Values) string {
-	return fmt.Sprintf("%s%s?%s", p.BaseUrl, path, params.Encode())
+	return fmt.Sprintf("%s%s?%s", p.ApiUrl, path, params.Encode())
 }


### PR DESCRIPTION
Allowing usage of `https://github.<company>.com/api/v3` in addition to `https://api.github.com/`.
Our ssl certificate only matches `github.com`.  The alternative base url matches the certificate while providing the same functionality.
